### PR TITLE
Provide user login to user authentication

### DIFF
--- a/src/main/resources/org/sonar/ror/cas/app/controllers/cas_controller.rb
+++ b/src/main/resources/org/sonar/ror/cas/app/controllers/cas_controller.rb
@@ -7,7 +7,7 @@ class CasController < ApplicationController
     begin
       login = nil
       assertion = servlet_request.getAttribute(org.jasig.cas.client.util.AbstractCasFilter::CONST_CAS_ASSERTION)
-      unless assertion.nil? && assertion.getPrincipal().nil?
+      unless assertion.nil? || assertion.getPrincipal().nil?
         login = assertion.getPrincipal().getName()
       end
       self.current_user = User.authenticate(login, nil, servlet_request)


### PR DESCRIPTION
The previous behaviour accidentally worked because the CAS plugin
provided user login as real name in the user details and Sonar
authentication code sets the login name to match the real name if
login name is missing but details are provided. The proper way
is to provide the login name properly in the first place. This
patch does exactly that.
