### PR TITLE
Enable populating user name and email with SAML 1.1 attributes

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -42,3 +42,8 @@ sonar.cas.sonarServerUrl=http://localhost:9000
 # Note that 10 seconds should be more than enough for most environments that have NTP time synchronization.
 # Default is 1000 milliseconds.
 #sonar.cas.saml11.toleranceMilliseconds=1000
+
+# SAML 1.1 tickets may contain attributes describing information about the authenticated user.
+# The attributes can be used to automatically populate the name and e-mail fields of Sonar users if provided.
+#sonar.cas.saml11.attribute.name=name
+#sonar.cas.saml11.attribute.email=email

--- a/src/main/java/org/sonar/plugins/cas/CasSecurityRealm.java
+++ b/src/main/java/org/sonar/plugins/cas/CasSecurityRealm.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.plugins.cas;
 
+import org.sonar.api.config.Settings;
 import org.sonar.api.security.Authenticator;
 import org.sonar.api.security.ExternalUsersProvider;
 import org.sonar.api.security.SecurityRealm;
@@ -27,6 +28,12 @@ public class CasSecurityRealm extends SecurityRealm {
 
   public static final String KEY = "cas";
 
+  private Settings settings;
+
+  public CasSecurityRealm(Settings settings) {
+    this.settings = settings;
+  }
+
   @Override
   public Authenticator doGetAuthenticator() {
     return new CasAuthenticator();
@@ -34,7 +41,7 @@ public class CasSecurityRealm extends SecurityRealm {
 
   @Override
   public ExternalUsersProvider getUsersProvider() {
-    return new CasUserProvider();
+    return new CasUserProvider(settings);
   }
 
   @Override

--- a/src/test/java/org/sonar/plugins/cas/CasSecurityRealmTest.java
+++ b/src/test/java/org/sonar/plugins/cas/CasSecurityRealmTest.java
@@ -20,13 +20,14 @@
 package org.sonar.plugins.cas;
 
 import org.junit.Test;
+import org.sonar.api.config.Settings;
 
 import static org.fest.assertions.Assertions.assertThat;
 
 public class CasSecurityRealmTest {
   @Test
   public void should_declare_components() {
-    CasSecurityRealm realm = new CasSecurityRealm();
+    CasSecurityRealm realm = new CasSecurityRealm(new Settings());
     assertThat(realm.doGetAuthenticator()).isInstanceOf(CasAuthenticator.class);
     assertThat(realm.getUsersProvider()).isInstanceOf(CasUserProvider.class);
     assertThat(realm.getName()).isEqualTo("cas");


### PR DESCRIPTION
It's possible to pass arbitrary attributes with the SAML 1.1 ticket.
Attributes are often used to pass the name and e-mail address of the
user to the application. This patch enables to configure which
attributes match the name and e-mail data and populates the user details
with the values found in the corresponding SAML attributes.

This patch requires b101991d675999052039c3e7a2745c7470c78c28 first to be applied in order to work correctly. Without that patch and using the functionality of this patch, the Sonar users will be named to match the real name defined in the user details, not the CAS account name the user used when authenticating with CAS. Thus Sonar and CAS user accounts don't match even though the user is authenticated ok.
